### PR TITLE
Fix remuneration date

### DIFF
--- a/src/components/employee/remuneration/remuneration-details.js
+++ b/src/components/employee/remuneration/remuneration-details.js
@@ -65,7 +65,7 @@ module.exports.calculate = (employee, remunerationDate) => {
     // UTEDYC - Labor union affiliation
     if (employee.isUnionMember)
         details.push({
-            description: 'Afiliación a UTEDYC,',
+            description: 'Afiliación a UTEDYC',
             value: subtotal * 0.025 * (-1)
         });
 

--- a/src/components/employee/remuneration/remuneration.service.js
+++ b/src/components/employee/remuneration/remuneration.service.js
@@ -63,7 +63,7 @@ module.exports.previewRemuneration = async (employeeId) => {
         const remunerationYear = employee.entryDate.getFullYear();
 
         newRemuneration = {
-            date: remunerationDate,
+            date: new Date(),
             paymentPeriod: `${remunerationMonthName} ${remunerationYear}`
         };
 


### PR DESCRIPTION
Quick fix:
- Removed incorrect comma on remuneration details item
- The remuneration date should be the current date, whilst the remuneration period should be the previous month.